### PR TITLE
Fix failure when NAs are present or there is only one observation

### DIFF
--- a/R/data_bars.R
+++ b/R/data_bars.R
@@ -246,7 +246,7 @@ data_bars <- function(data,
 
   cell <- function(value, index, name) {
 
-    if (!is.numeric(value)) return(value)
+    if (is.na(value) || !is.numeric(value)) return(value)
 
     ### stop messages
     if (!is.logical(fill_gradient)) {
@@ -358,7 +358,9 @@ data_bars <- function(data,
     }
 
     ### normalization for color palette
-    if (stats::var(data[[name]]) == 0) {
+    data_var <- stats::var(data[[name]], na.rm = TRUE)
+
+    if (is.na(data_var) || data_var == 0) {
 
       normalized <- 1
 


### PR DESCRIPTION
data_bars fails when NAs are present or when there is only one observation and variance is NA. For example:

Case 1: `data <- data.frame(Pct1 = c(1, NA), Pct2 = c(NA, 0.5))`
Case 2: `data <- data.frame(Pct1 = 1, Pct2 = 0.5)`

And then:

```
reactable(
  data,
  pagination = FALSE,
  defaultColDef = colDef(
    cell = data_bars(data,
                     text_position = "center",
                     min_value = 0,
                     max_value = 1,
                     number_fmt = scales::percent)
  )
)
```

Gives "Error in if [...] : missing value where TRUE/FALSE needed"

After the change:

Case 1:
<img src = "https://user-images.githubusercontent.com/41536896/146851190-dd91513b-26c9-457d-b23b-7f59f6c4b46c.png" width = 500>

Case 2:
<img src = "https://user-images.githubusercontent.com/41536896/146851215-173e8c7d-10fc-4728-adb6-62cc7922cfce.png" width = 500>
