### PR TITLE
add color by example

### DIFF
--- a/vignettes/color_scales.Rmd
+++ b/vignettes/color_scales.Rmd
@@ -243,7 +243,32 @@ reactable(
 )
 ```
 
+## Color assignments by another column
 
+In the dev version of `reactable`, there is a `color_by` argument that allows for 
+color assignment based on the values in another column.  If desired, the `color_by`
+columns may be hidden.
+
+```{r}
+reactable(
+  data,
+  columns = list(
+    Type = colDef(style = color_scales(data, color_by = "MPG.city"))
+  )
+)
+```
+
+If desired, the `color_by` columns may be hidden.
+
+```{r}
+reactable(
+  data,
+  columns = list(
+    Type = colDef(style = color_scales(data, color_by = "MPG.city")),
+    MPG.city = colDef(show = FALSE)
+  )
+)
+```
 
 ## Row-wise styling
 

--- a/vignettes/color_scales.Rmd
+++ b/vignettes/color_scales.Rmd
@@ -246,8 +246,7 @@ reactable(
 ## Color assignments by another column
 
 In the dev version of `reactable`, there is a `color_by` argument that allows for 
-color assignment based on the values in another column.  If desired, the `color_by`
-columns may be hidden.
+color assignment based on the values in another column.  
 
 ```{r}
 reactable(

--- a/vignettes/color_scales.Rmd
+++ b/vignettes/color_scales.Rmd
@@ -245,7 +245,7 @@ reactable(
 
 ## Color assignments by another column
 
-In the dev version of `reactable`, there is a `color_by` argument that allows for 
+In the dev version of `{reactablefmtr}`, there is a `color_by` argument that allows for 
 color assignment based on the values in another column.  
 
 ```{r}


### PR DESCRIPTION
Hi Kyle!  Here is a quick example to add to the `color_scales` vignette.  It may not be the most sensible, but it is readily available. Happy to make another PR for `color_tiles` if you like it.