### PR TITLE
Respect user-supplied color range values when supplied zero-variance columns

### DIFF
--- a/R/color_tiles.R
+++ b/R/color_tiles.R
@@ -482,11 +482,6 @@ color_tiles <- function(data,
 
         } else {
 
-          effective_min_value <- coalesce(c(min_value, min(data[[name]], na.rm = TRUE)))
-          effective_max_value <- coalesce(c(max_value, max(data[[name]], na.rm = TRUE)))          
-          range <- effective_max_value - effective_min_value
-          normalized <- if (range > 0) (value - min_value_normal) / range else 1
-
           if (!is.null(min_value) & isTRUE(min_value > min(data[[name]], na.rm = TRUE))) {
 
             stop("`min_value` must be less than the minimum value observed in the data")
@@ -496,7 +491,12 @@ color_tiles <- function(data,
 
             stop("`max_value` must be greater than the maximum value observed in the data")
           }
-
+          
+          effective_min_value <- coalesce(c(min_value, min(data[[name]], na.rm = TRUE)))
+          effective_max_value <- coalesce(c(max_value, max(data[[name]], na.rm = TRUE)))          
+          range <- effective_max_value - effective_min_value
+          normalized <- if (range > 0) (value - min_value_normal) / range else 1
+            
           cell_color <- color_pal(normalized)
           cell_color <- suppressWarnings(grDevices::adjustcolor(cell_color, alpha.f = opacity))
           font_color <- assign_color(normalized)

--- a/R/color_tiles.R
+++ b/R/color_tiles.R
@@ -496,7 +496,7 @@ color_tiles <- function(data,
           effective_min_value <- null_replace(min_value, min(data[[name]], na.rm = TRUE))
           effective_max_value <- null_replace(max_value, max(data[[name]], na.rm = TRUE))          
           range <- effective_max_value - effective_min_value
-          normalized <- if (range > 0) (value - min_value_normal) / range else 1
+          normalized <- if (range > 0) (value - effective_min_value) / range else 1
             
           cell_color <- color_pal(normalized)
           cell_color <- suppressWarnings(grDevices::adjustcolor(cell_color, alpha.f = opacity))

--- a/R/color_tiles.R
+++ b/R/color_tiles.R
@@ -492,8 +492,9 @@ color_tiles <- function(data,
             stop("`max_value` must be greater than the maximum value observed in the data")
           }
           
-          effective_min_value <- coalesce(c(min_value, min(data[[name]], na.rm = TRUE)))
-          effective_max_value <- coalesce(c(max_value, max(data[[name]], na.rm = TRUE)))          
+          null_replace <- function(a, b) if (is.null(a)) b else a
+          effective_min_value <- null_replace(min_value, min(data[[name]], na.rm = TRUE)))
+          effective_max_value <- null_replace(max_value, max(data[[name]], na.rm = TRUE)))          
           range <- effective_max_value - effective_min_value
           normalized <- if (range > 0) (value - min_value_normal) / range else 1
             

--- a/R/color_tiles.R
+++ b/R/color_tiles.R
@@ -482,26 +482,10 @@ color_tiles <- function(data,
 
         } else {
 
-          # standard normalization (no variance check)
-          if (is.numeric(value) & mean((data[[name]] - mean(data[[name]], na.rm=TRUE)) ^ 2, na.rm=TRUE) == 0) {
-
-            normalized <- 1
-
-          } else {
-
-            # user supplied min and max values
-            if (is.null(min_value)) {
-              min_value_normal <- min(data[[name]], na.rm = TRUE)
-            } else { min_value_normal <- min_value }
-
-            if (is.null(max_value)) {
-              max_value_normal <- max(data[[name]], na.rm = TRUE)
-            } else { max_value_normal <- max_value }
-
-            # standard normalization
-            normalized <- (value - min_value_normal) / (max_value_normal - min_value_normal)
-
-          }
+          effective_min_value <- coalesce(c(min_value, min(data[[name]], na.rm = TRUE)))
+          effective_max_value <- coalesce(c(max_value, max(data[[name]], na.rm = TRUE)))          
+          range <- effective_max_value - effective_min_value
+          normalized <- if (range > 0) (value - min_value_normal) / range else 1
 
           if (!is.null(min_value) & isTRUE(min_value > min(data[[name]], na.rm = TRUE))) {
 

--- a/R/color_tiles.R
+++ b/R/color_tiles.R
@@ -493,8 +493,8 @@ color_tiles <- function(data,
           }
           
           null_replace <- function(a, b) if (is.null(a)) b else a
-          effective_min_value <- null_replace(min_value, min(data[[name]], na.rm = TRUE)))
-          effective_max_value <- null_replace(max_value, max(data[[name]], na.rm = TRUE)))          
+          effective_min_value <- null_replace(min_value, min(data[[name]], na.rm = TRUE))
+          effective_max_value <- null_replace(max_value, max(data[[name]], na.rm = TRUE))          
           range <- effective_max_value - effective_min_value
           normalized <- if (range > 0) (value - min_value_normal) / range else 1
             

--- a/R/color_tiles.R
+++ b/R/color_tiles.R
@@ -451,25 +451,12 @@ color_tiles <- function(data,
 
             if (is.character(color_by)) { color_by <- which(names(data) %in% color_by) }
 
-            # if there is no variance in the column, assign the same color to each value
-            if (is.numeric(data[[color_by]]) & mean((data[[color_by]] - mean(data[[color_by]], na.rm=TRUE)) ^ 2, na.rm=TRUE) == 0) {
-
-              normalized <- 1
-
-            } else {
-
-              # user supplied min and max values
-              if (is.null(min_value)) {
-                min_value_color_by <- min(data[[color_by]], na.rm = TRUE)
-              } else { min_value_color_by <- min_value }
-
-              if (is.null(max_value)) {
-                max_value_color_by <- max(data[[color_by]], na.rm = TRUE)
-              } else { max_value_color_by <- max_value }
-
-              normalized <- (data[[color_by]][index] - min_value_color_by) / (max_value_color_by - min_value_color_by)
-
-            }
+            # utilize min and and max values if supplied, otherwise use data extents
+            null_replace <- function(a, b) if (is.null(a)) b else a
+            effective_min_value <- null_replace(min_value, min(data[[color_by]], na.rm = TRUE))
+            effective_max_value <- null_replace(max_value, max(data[[color_by]], na.rm = TRUE))          
+            range <- effective_max_value - effective_min_value
+            normalized <- if (range > 0) (data[[color_by]][index] - effective_min_value) / range else 1
 
             cell_color <- color_pal(normalized)
             cell_color <- suppressWarnings(grDevices::adjustcolor(cell_color, alpha.f = opacity))
@@ -492,6 +479,7 @@ color_tiles <- function(data,
             stop("`max_value` must be greater than the maximum value observed in the data")
           }
           
+          # utilize min and and max values if supplied, otherwise use data extents
           null_replace <- function(a, b) if (is.null(a)) b else a
           effective_min_value <- null_replace(min_value, min(data[[name]], na.rm = TRUE))
           effective_max_value <- null_replace(max_value, max(data[[name]], na.rm = TRUE))          


### PR DESCRIPTION
The zero-variance checks cause user-supplied color range values (min_value & max_values) to be ignored.  I believe this edit captures the indended behavior.